### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel-loader": "^8.0.2",
     "chai": "^4.1.2",
     "css-loader": "^1.0.0",
-    "cssnano": "^4.1.3",
     "eslint": "^5.5.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-loader": "^2.1.0",
@@ -55,7 +54,6 @@
     "karma-webpack": "^3.0.5",
     "mocha": "^5.2.0",
     "node-sass": "^4.9.3",
-    "postcss-import": "^12.0.0",
     "rollup": "^0.65.2",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-commonjs": "^9.1.6",
@@ -74,6 +72,8 @@
     "webpack-dev-server": "^3.1.7"
   },
   "dependencies": {
-    "perfect-scrollbar": "^1.4.0"
+    "cssnano": "^4.1.3",
+    "perfect-scrollbar": "^1.4.0",
+    "postcss-import": "^12.0.0"
   }
 }


### PR DESCRIPTION
Closes #5 

@mercs600 users aren't getting an error about `cssnano` because it's installed already by the vue-cli, but that should also be in dependencies, so I've moved it too. You could of course also make them peerDependencies and add a note to the readme, if you prefer that let me know 🙂 