### PR TITLE
Add static class to avoid removing after Vue merge vnode classes

### DIFF
--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -46,6 +46,7 @@ export default {
     return h(this.tag,
       {
         ref: 'container',
+        class: 'ps',
         on: this.$listeners
       },
       this.$slots.default)


### PR DESCRIPTION
resolves #16 

So.. the problem is that .ps class is added by native js way in perfect scrollbar sources. Then Vue.js during generate classes for vnode and merge classes takes into account only vnode classes I mean staticClass and class - so these classes can be only added on vue component level.  See more here https://github.com/vuejs/vue/blob/e90cc60c4718a69e2c919275a999b7370141f3bf/dist/vue.runtime.common.dev.js#L5484 and issue related with that -> https://github.com/vuejs/vue/issues/3975 

So the better way is just add this class on component level. 